### PR TITLE
Remove SHA-256 digest algorithm hardcoding when creating response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/digitorus/timestamp
 go 1.16
 
 require github.com/digitorus/pkcs7 v0.0.0-20221019075359-21b8b40e6bb4
+
+replace github.com/digitorus/pkcs7 => github.com/malancas/pkcs7 v0.0.0-20230515132222-355800eab5f5

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.16
 
 require github.com/digitorus/pkcs7 v0.0.0-20221019075359-21b8b40e6bb4
 
-replace github.com/digitorus/pkcs7 => github.com/malancas/pkcs7 v0.0.0-20230515132222-355800eab5f5
+replace github.com/digitorus/pkcs7 => github.com/haydentherapper/pkcs7 v0.0.0-20230626203926-9982c401a2fb

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/digitorus/pkcs7 v0.0.0-20221019075359-21b8b40e6bb4 h1:MxNIia2F3bgFyNsOZy9UbNlpKAxbtCudkVmlJBNuvmg=
-github.com/digitorus/pkcs7 v0.0.0-20221019075359-21b8b40e6bb4/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=
+github.com/malancas/pkcs7 v0.0.0-20230515132222-355800eab5f5 h1:h6KmvJFVomYfHennbR1Cy6Zhp93jyHZddHxXJCRaxxs=
+github.com/malancas/pkcs7 v0.0.0-20230515132222-355800eab5f5/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/malancas/pkcs7 v0.0.0-20230515132222-355800eab5f5 h1:h6KmvJFVomYfHennbR1Cy6Zhp93jyHZddHxXJCRaxxs=
-github.com/malancas/pkcs7 v0.0.0-20230515132222-355800eab5f5/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=
+github.com/haydentherapper/pkcs7 v0.0.0-20230626203926-9982c401a2fb h1:+SUAUbIpNMX0UBNbBLjBBiShLn+WSqoVGi+8N6jMLr8=
+github.com/haydentherapper/pkcs7 v0.0.0-20230626203926-9982c401a2fb/go.mod h1:SKVExuS+vpu2l9IoOc0RwqE7NYnb0JlcFHFnEJkVDzc=

--- a/rfc3161_struct.go
+++ b/rfc3161_struct.go
@@ -45,7 +45,7 @@ func (s pkiStatusInfo) FailureInfo() FailureInfo {
 		}
 	}
 
-	return UnkownFailureInfo
+	return UnknownFailureInfo
 }
 
 // eContent within SignedData is TSTInfo

--- a/timestamp.go
+++ b/timestamp.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math/big"
@@ -151,16 +150,26 @@ type Request struct {
 	ExtraExtensions []pkix.Extension
 }
 
-func buildRequest(req request) (*Request, error) {
+// ParseRequest parses an timestamp request in DER form.
+func ParseRequest(bytes []byte) (*Request, error) {
+	var err error
+	var rest []byte
+	var req request
+
+	if rest, err = asn1.Unmarshal(bytes, &req); err != nil {
+		return nil, err
+	}
+	if len(rest) > 0 {
+		return nil, ParseError("trailing data in Time-Stamp request")
+	}
+
 	if len(req.MessageImprint.HashedMessage) == 0 {
 		return nil, ParseError("Time-Stamp request contains no hashed message")
 	}
-
 	hashFunc := getHashAlgorithmFromOID(req.MessageImprint.HashAlgorithm.Algorithm)
 	if hashFunc == crypto.Hash(0) {
 		return nil, ParseError("Time-Stamp request uses unknown hash function")
 	}
-
 	return &Request{
 		HashAlgorithm: hashFunc,
 		HashedMessage: req.MessageImprint.HashedMessage,
@@ -169,32 +178,6 @@ func buildRequest(req request) (*Request, error) {
 		TSAPolicyOID:  req.ReqPolicy,
 		Extensions:    req.Extensions,
 	}, nil
-}
-
-// ParseRequestFromJSON parses an timestamp request in JSON form.
-func ParseRequestFromJSON(bytes []byte) (*Request, error) {
-	var req request
-
-	if err := json.Unmarshal(bytes, &req); err != nil {
-		return nil, err
-	}
-
-	return buildRequest(req)
-}
-
-// ParseRequest parses an timestamp request in DER form.
-func ParseRequest(bytes []byte) (*Request, error) {
-	var req request
-
-	rest, err := asn1.Unmarshal(bytes, &req)
-	if err != nil {
-		return nil, err
-	}
-	if len(rest) > 0 {
-		return nil, ParseError("trailing data in Time-Stamp request")
-	}
-
-	return buildRequest(req)
 }
 
 // Marshal marshals the Time-Stamp request to ASN.1 DER encoded form.

--- a/timestamp.go
+++ b/timestamp.go
@@ -553,7 +553,7 @@ func (t *Timestamp) populateSigningCertificateV2Ext(certificate *x509.Certificat
 		return nil, x509.ErrUnsupportedAlgorithm
 	}
 	if t.HashAlgorithm.HashFunc() == crypto.SHA1 {
-		return nil, fmt.Errorf("for SHA1 usae ESSCertID instead of ESSCertIDv2")
+		return nil, fmt.Errorf("for SHA1 use ESSCertID instead of ESSCertIDv2")
 	}
 
 	h := t.HashAlgorithm.HashFunc().New()
@@ -596,7 +596,9 @@ func (t *Timestamp) generateSignedData(tstInfo []byte, signer crypto.Signer, cer
 	if err != nil {
 		return nil, err
 	}
-	signedData.SetDigestAlgorithm(pkcs7.OIDDigestAlgorithmSHA256)
+
+	digestAlgOID := getOIDFromHashAlgorithm(t.HashAlgorithm)
+	signedData.SetDigestAlgorithm(digestAlgOID)
 	signedData.SetContentType(asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 16, 1, 4})
 
 	signingCertV2Bytes, err := t.populateSigningCertificateV2Ext(certificate)
@@ -632,7 +634,7 @@ func (t *Timestamp) generateSignedData(tstInfo []byte, signer crypto.Signer, cer
 	return signature, nil
 }
 
-// copied from cryto/x509 package
+// copied from crypto/x509 package
 // oidNotInExtensions reports whether an extension with the given oid exists in
 // extensions.
 func oidInExtensions(oid asn1.ObjectIdentifier, extensions []pkix.Extension) bool {

--- a/timestamp.go
+++ b/timestamp.go
@@ -23,8 +23,8 @@ import (
 type FailureInfo int
 
 const (
-	// UnkownFailureInfo mean that no known failure info was provided
-	UnkownFailureInfo FailureInfo = -1
+	// UnknownFailureInfo mean that no known failure info was provided
+	UnknownFailureInfo FailureInfo = -1
 	// BadAlgorithm defines an unrecognized or unsupported Algorithm Identifier
 	BadAlgorithm FailureInfo = 0
 	// BadRequest indicates that the transaction not permitted or supported
@@ -268,7 +268,7 @@ func ParseResponse(bytes []byte) (*Timestamp, error) {
 	if resp.Status.Status > 0 {
 		var fis string
 		fi := resp.Status.FailureInfo()
-		if fi != UnkownFailureInfo {
+		if fi != UnknownFailureInfo {
 			fis = fi.String()
 		}
 		return nil, fmt.Errorf("%s: %s (%v)",

--- a/timestamp.go
+++ b/timestamp.go
@@ -166,10 +166,12 @@ func ParseRequest(bytes []byte) (*Request, error) {
 	if len(req.MessageImprint.HashedMessage) == 0 {
 		return nil, ParseError("Time-Stamp request contains no hashed message")
 	}
+
 	hashFunc := getHashAlgorithmFromOID(req.MessageImprint.HashAlgorithm.Algorithm)
 	if hashFunc == crypto.Hash(0) {
 		return nil, ParseError("Time-Stamp request uses unknown hash function")
 	}
+
 	return &Request{
 		HashAlgorithm: hashFunc,
 		HashedMessage: req.MessageImprint.HashedMessage,


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This removes the hardcoded use of SHA-256 when setting the digest algorithm OID within the timestamp response. Instead the OID is retrieved using the signing certificate's signature algorithm with the `pkcs7.GetDigestOIDForSignatureAlgorithm` function, which will be exported in https://github.com/haydentherapper/pkcs7/pull/5. If exporting `pkcs7.GetDigestOIDForSignatureAlgorithm` makes the most sense, I will update this pull request after that one is merged remove the `replace` statement in `go.mod`.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->